### PR TITLE
[Fix] 준비된 말풍선 데이터가 없으면 말풍선이 안뜨도록 수정

### DIFF
--- a/Assets/WorkSpace/JTW/Scripts/StoryObject/StoryPopUpPresenter.cs
+++ b/Assets/WorkSpace/JTW/Scripts/StoryObject/StoryPopUpPresenter.cs
@@ -14,7 +14,13 @@ public class StoryPopUpPresenter : BaseUI
             Destroy(this.gameObject);
 
             string dialogueId = Manager.Data.StoryDescriptionData.Values[_storyId].PlayerDialogueID;
-            Manager.UI.Inven.ShowBubbleText(Manager.Data.PlayerDialogueData.Values[dialogueId].Dialogue_kr);
+
+            if (!string.IsNullOrEmpty(dialogueId))
+            {
+                string dialogue = Manager.Data.PlayerDialogueData.Values[dialogueId].Dialogue_kr;
+                Manager.UI.Inven.ShowBubbleText(dialogue);
+            }
+            
         }
     }
 


### PR DESCRIPTION
story 데이터에 따라 말풍선이 없는 경우도 있으므로, 없는 경우 말풍선이 뜨지 않도록 수정.