### PR TITLE
[Fix] 파괴될 때, 스탯이 아니라 Value를 null로 하도록 수정

### DIFF
--- a/Assets/WorkSpace/KBK/Scripts/Item.cs
+++ b/Assets/WorkSpace/KBK/Scripts/Item.cs
@@ -133,11 +133,11 @@ public class Item : ScriptableObject, IUsableID
     {
         if(itemType == ItemType.Weapon)
         {
-            Manager.Player.Stats.Weapon = null;
+            Manager.Player.Stats.Weapon.Value = null;
         }
         else if(itemType == ItemType.Armor)
         {
-            Manager.Player.Stats.Armor = null;
+            Manager.Player.Stats.Armor.Value = null;
         }
     }
 }


### PR DESCRIPTION
스탯 자체를 null로 설정하던 것을 Value를 null로 설정하도록 수정.