### PR TITLE
[Feat] ItemBox Trade 로직 변경

### DIFF
--- a/Assets/WorkSpace/JTW/Scripts/ItemBox/ItemBoxPresenter.cs
+++ b/Assets/WorkSpace/JTW/Scripts/ItemBox/ItemBoxPresenter.cs
@@ -154,11 +154,17 @@ public class ItemBoxPresenter : BaseUI, IInventory
 
         SlotUI selectedSlotUI = _selectedItemSlots.SlotUIs[_selectedItemSlots.SelectedSlotIndex];
 
+        Item item = selectedSlotUI.Slot.CurItem;
+
+        if (item == null) return;
+
         if (IsTrade)
         {
-            Item item = selectedSlotUI.Slot.CurItem;
-
-            if (item != null)
+            if(item.itemType == ItemType.Weapon || item.itemType == ItemType.Armor)
+            {
+                selectedSlotUI.UseItem();
+            }
+            else
             {
                 if (!_inventoryForTrade.AddItem(item)) return;
                 selectedSlotUI.Slot.RemoveItem();
@@ -166,6 +172,8 @@ public class ItemBoxPresenter : BaseUI, IInventory
         }
         else
         {
+            if (item.itemType == ItemType.Weapon || item.itemType == ItemType.Armor) return;
+
             selectedSlotUI.UseItem();
         }
 


### PR DESCRIPTION
베이스 캠프에서 무기와 방어구는 사용하지 못하도록 변경.

파밍 준비 단계에서 무기와 방어구는 전용 장착 슬롯에 하나만 들고 갈 수 있도록 변경.