### PR TITLE
[Fix] DataManager 빌드 오류 수정

### DIFF
--- a/Assets/WorkSpace/JTW/Scripts/Invnetory/SlotUI.cs
+++ b/Assets/WorkSpace/JTW/Scripts/Invnetory/SlotUI.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
-using static UnityEditor.Progress;
-using static UnityEngine.Rendering.DebugUI;
 
 public class SlotUI : MonoBehaviour
 {

--- a/Assets/WorkSpace/JTW/Scripts/Manager/DataManager.cs
+++ b/Assets/WorkSpace/JTW/Scripts/Manager/DataManager.cs
@@ -6,7 +6,6 @@ using Unity.Burst.CompilerServices;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Networking;
-using static UnityEditor.Progress;
 
 public class DataManager : Singleton<DataManager>
 {
@@ -85,8 +84,8 @@ public class DataManager : Singleton<DataManager>
             item.itemName = words[1].Trim();
             item.description = words[2].Trim();
             string iconName = words[6].Trim();
-            string iconPath = $"Assets/Imports/UnityCrossClassProject_Assets/Icons/{words[0]}.png";
-            Sprite icon = AssetDatabase.LoadAssetAtPath<Sprite>(iconPath);
+            string iconPath = $"Icons/{words[0]}";
+            Sprite icon = Resources.Load<Sprite>(iconPath);
             item.icon = icon;
 
             int.TryParse(words[7], out item.itemTier);
@@ -325,8 +324,8 @@ public class DataManager : Singleton<DataManager>
             Manager.Game.IsGetSubStory[words[0]] = false;
 
             string iconName = words[1].Trim();
-            string iconPath = $"Assets/Imports/UnityCrossClassProject_Assets/Icons/{iconName}.png";
-            Sprite icon = AssetDatabase.LoadAssetAtPath<Sprite>(iconPath);
+            string iconPath = $"Icons/{iconName}";
+            Sprite icon = Resources.Load<Sprite>(iconPath);
             story.Icon = icon;
             story.Name = words[2];
             story.Description = words[3];
@@ -378,8 +377,8 @@ public class DataManager : Singleton<DataManager>
             storyInteraction.ID = words[0];
 
             string iconName = words[1].Trim();
-            string iconPath = $"Assets/Imports/UnityCrossClassProject_Assets/StoryInteractionIcon/{iconName}.png";
-            Sprite icon = AssetDatabase.LoadAssetAtPath<Sprite>(iconPath);
+            string iconPath = $"StoryInteractionIcon/{iconName}";
+            Sprite icon = Resources.Load<Sprite>(iconPath);
             storyInteraction.Icon = icon;
 
             storyInteraction.Description_kr = words[2];

--- a/Assets/WorkSpace/KBK/Scripts/Item.cs
+++ b/Assets/WorkSpace/KBK/Scripts/Item.cs
@@ -1,4 +1,3 @@
-using UnityEditor.VisionOS;
 using UnityEngine;
 using System;
 

--- a/Assets/WorkSpace/KBK/Scripts/ItemCSVConnecter.cs
+++ b/Assets/WorkSpace/KBK/Scripts/ItemCSVConnecter.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -59,6 +60,6 @@ public class ItemCSVConnecter
     }
 }
 
-
+#endif
 
 

--- a/Assets/WorkSpace/LSJ/scripts/TextPopUp.cs
+++ b/Assets/WorkSpace/LSJ/scripts/TextPopUp.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using TMPro;
-using UnityEditor.VersionControl;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,11 +6,8 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/WorkSpace/LSJ/TitleScene.unity
-    guid: 14f7b5a61f5992a4da63acfabc5b1b13
-  - enabled: 1
-    path: Assets/WorkSpace/LSJ/New Scene.unity
-    guid: 87567ecd5faf8844198fdf343390be9d
+    path: Assets/WorkSpace/JTW/Demo2/Scene/TitleScene.unity
+    guid: 702cf79ef6ee6ad4989c361733cd8c8c
   - enabled: 1
     path: Assets/WorkSpace/JTW/Demo2/Scene/Tutorial.unity
     guid: 0ee673fe070d48047839f1193edf2d6c
@@ -19,8 +16,14 @@ EditorBuildSettings:
     guid: b527b339a503de545b6121e44a52426d
   - enabled: 1
     path: Assets/WorkSpace/JTW/Demo2/Scene/Hospital.unity
-    guid: 0f88ee8efb6881943a86a5ddba56a54b
+    guid: f2f6d913d606a074eab9a7369ebd3df2
   - enabled: 1
     path: Assets/WorkSpace/JTW/Demo2/Scene/School.unity
-    guid: ddd11a2230d67b3439b6e5415c2fcd62
+    guid: c3636b293086ab347a3a8af74f591584
+  - enabled: 1
+    path: Assets/WorkSpace/LSJ/TitleScene.unity
+    guid: 14f7b5a61f5992a4da63acfabc5b1b13
+  - enabled: 1
+    path: Assets/WorkSpace/LSJ/New Scene.unity
+    guid: 87567ecd5faf8844198fdf343390be9d
   m_configObjects: {}


### PR DESCRIPTION
DataManager에서 빌드 AssetDatabase는 빌드 시 사용하지 못하므로 Resources 폴더를 이용하는 방식으로 수정.

그외 빌드에 포함하지 못하는 using 문 제거