### PR TITLE
[Fix] 중간에 죽어서 로드되면 아이템이 2배가 되는 현상 수정

### DIFF
--- a/Assets/WorkSpace/JTW/Scripts/Manager/GameManager.cs
+++ b/Assets/WorkSpace/JTW/Scripts/Manager/GameManager.cs
@@ -41,6 +41,7 @@ public class GameManager : Singleton<GameManager>
 
         if (data == null)
         {
+            InitGameData();
             Manager.Player.Stats.InitStats();
             ChangeScene("Tutorial");
         }
@@ -117,8 +118,41 @@ public class GameManager : Singleton<GameManager>
         _saveContoroller.SaveGameData();
     }
 
+    private void InitGameData()
+    {
+        Manager.Player.Stats = new PlayerStats();
+
+        Inven = new Inventory();
+        ItemBox = new ItemBoxData();
+
+        IsRepairObject = new Dictionary<string, bool>();
+        IsUsedObject = new Dictionary<string, bool>();
+        foreach (string str in Manager.Data.RefairData.Values.Keys.ToArray())
+        {
+            IsRepairObject[str] = false;
+            IsUsedObject[str] = false;
+        }
+
+        IsGetSubStory = new Dictionary<string, bool>();
+        foreach (string str in Manager.Data.StoryDescriptionData.Values.Keys.ToArray())
+        {
+            IsGetSubStory[str] = false;
+        }
+
+        IsTalkDialogue = new Dictionary<string, bool>();
+        foreach (string str in Manager.Data.PlayerDialogueData.Values.Keys.ToArray())
+        {
+            IsTalkDialogue[str] = false;
+        }
+
+        IsInBaseCamp = false;
+        SelectedMapName = "Tutorial";
+    }
+
     public void LoadSaveData(GameData data)
     {
+        InitGameData();
+
         Manager.Player.Stats = data.stats;
         Manager.Player.Stats.Weapon = new Stat<Item>();
         Manager.Player.Stats.Armor = new Stat<Item>();


### PR DESCRIPTION
세이브 데이터 로드 시 데이터의 초기화를 먼저 진행하도록 로직 변경